### PR TITLE
fix: recomposition in ContextualFlowRow

### DIFF
--- a/emoji-compose/src/commonMain/kotlin/org/kodein/emoji/compose/text.kt
+++ b/emoji-compose/src/commonMain/kotlin/org/kodein/emoji/compose/text.kt
@@ -47,15 +47,10 @@ private fun WithNotoEmoji(
                 append(text.substring(start, found.start))
             val inlineContentID = "emoji:${found.emoji}"
             inlineContent[inlineContentID] = InlineTextContent(Placeholder(found.emoji.ratio().em, 1.em, PlaceholderVerticalAlign.Center)) {
-                var display: (@Composable () -> Unit)? by remember { mutableStateOf(null) }
-                LaunchedEffect(null) {
-                    display = createDisplay(found.emoji)
+                val display by produceState<(@Composable () -> Unit)?>(null, found.emoji) {
+                    value = createDisplay(found.emoji)
                 }
-                if (display == null) {
-                    placeholder(found.emoji)
-                } else {
-                    display!!.invoke()
-                }
+                display?.invoke() ?: placeholder(found.emoji)
             }
             appendInlineContent(inlineContentID)
             start = found.end


### PR DESCRIPTION
Hi, when using TextWithNotoAnimatedEmoji in a new ContextualFlowRow in compose, duplication occurs. I think it is caused by the inlineContent not adding the key correctly.